### PR TITLE
Update call to deprecated Smarty::get_template_vars

### DIFF
--- a/aggregatehouseholdcontributions.php
+++ b/aggregatehouseholdcontributions.php
@@ -233,7 +233,7 @@ class me_twomice_civicrm_aggregatehouseholdcontributions extends CRM_Report_Form
 
     // Place all these new fields into the template in 'beginHookFormElements'
     $tpl = CRM_Core_Smarty::singleton();
-    $bhfe = $tpl->get_template_vars('beginHookFormElements');
+    $bhfe = $tpl->getTemplateVars('beginHookFormElements');
     if (!$bhfe) {
       $bhfe = array();
     }


### PR DESCRIPTION
Replaces deprecated function name with the forward-compat equivalent.

Note: the new getTemplateVars function has been available since CiviCRM 5.70.